### PR TITLE
Use HTTParty instead of octokit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@
 
 source "https://rubygems.org"
 
+gem "httparty"
 gem "octokit", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,13 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    multi_xml (0.6.0)
     octokit (5.6.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -20,6 +27,7 @@ PLATFORMS
   arm64-darwin-21
 
 DEPENDENCIES
+  httparty
   octokit (~> 5.0)
 
 BUNDLED WITH

--- a/api_client.rb
+++ b/api_client.rb
@@ -1,10 +1,7 @@
-require 'octokit'
+require 'httparty'
 
 # Provide authentication credentials
-client = Octokit::Client.new(:access_token => ENV["DEPENDABOT_REPORTER_TOKEN"])
+access_token = ENV["DEPENDABOT_REPORTER_TOKEN"]
 
-# You can still use the username/password syntax by replacing the password value with your PAT.
-# client = Octokit::Client.new(:login => 'defunkt', :password => 'personal_access_token')
-
-# Fetch the current user
-client.user
+HTTParty.get("https://api.github.com/repos/pulibrary/figgy/dependabot/alerts", headers: {"Accept" => "application/vnd.github+json", "
+Authorization" => "Bearer #{access_token}", "X-GitHub-Api-Version" => "2022-11-28"})


### PR DESCRIPTION
octokit did not provide the github endpoint that we required.

Co-authored-by: Anna Headley <hackartisan@users.noreply.github.com>
